### PR TITLE
CI: Jenkinsfile - mac package testing can retry upto 3 times on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,6 +365,7 @@ pipeline {
                                                         checkout scm
                                                         unstash 'PYTHON_PACKAGES'
                                                     },
+                                                    retries: 3,
                                                     testCommand: {
                                                         findFiles(glob: 'dist/*.tar.gz').each{
                                                             sh(label: 'Running Tox',


### PR DESCRIPTION
CI: Jenkinsfile - mac package testing can retry upto 3 times on failure