### PR TITLE
ci: Source and wheel formats can retry upto 2 times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,6 +303,9 @@ pipeline {
             }
             stages{
                 stage('Source and Wheel formats'){
+                    options{
+                      retry(2)
+                    }
                     agent {
                         docker {
                             image 'python'


### PR DESCRIPTION
Since Docker has a memory bug on some linux distros, it's not the fault of the pipeline or the project that the pipeline falls sometimes.